### PR TITLE
DiffFinder fix parallel install to ShelvesetComparer

### DIFF
--- a/DiffFinder/ShelvesetComparer.cs
+++ b/DiffFinder/ShelvesetComparer.cs
@@ -38,7 +38,7 @@ namespace DiffFinder
         /// <summary>
         /// Command menu group (command set GUID).
         /// </summary>
-        public static readonly Guid CommandSet = new Guid("b8e98565-7b6d-4d64-b51d-97fe5e56c5ec");
+        public static readonly Guid CommandSet = new Guid("667E3733-CFA5-4E39-B8E0-8732F02CDB56");
 
         /// <summary>
         /// VS Package that provides this command, not null.

--- a/DiffFinder/ShelvesetComparerPackage.cs
+++ b/DiffFinder/ShelvesetComparerPackage.cs
@@ -38,7 +38,7 @@ namespace DiffFinder
         /// <summary>
         /// ShelvesetComparerPackage GUID string.
         /// </summary>
-        public const string PackageGuidString = "7359eac9-15de-4749-9ef6-28177437ec9c";
+        public const string PackageGuidString = "59997A1F-A9CE-4016-9A89-F86342F99111";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ShelvesetComparerPackage"/> class.

--- a/DiffFinder/ShelvesetComparerPackage.vsct
+++ b/DiffFinder/ShelvesetComparerPackage.vsct
@@ -86,10 +86,10 @@
 
   <Symbols>
     <!-- This is the package guid. -->
-    <GuidSymbol name="guidShelvesetComparerPackage" value="{7359eac9-15de-4749-9ef6-28177437ec9c}" />
+    <GuidSymbol name="guidShelvesetComparerPackage" value="{59997A1F-A9CE-4016-9A89-F86342F99111}" />
 
     <!-- This is the guid used to group the menu commands together -->
-    <GuidSymbol name="guidShelvesetComparerPackageCmdSet" value="{b8e98565-7b6d-4d64-b51d-97fe5e56c5ec}">
+    <GuidSymbol name="guidShelvesetComparerPackageCmdSet" value="{667E3733-CFA5-4E39-B8E0-8732F02CDB56}">
       <IDSymbol name="IDM_ShelvesetComparer_MENU_TEAM" value="0x1020" />
       <IDSymbol name="IDM_ShelvesetComparer_TEAM_DROPDOWN" value="0x1021" />
 

--- a/DiffFinder/source.extension.vsixmanifest
+++ b/DiffFinder/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="c3b55d75-8ea6-3936-a8853-1d105zd38z19" Version="1.0.4.22" Language="en-US" Publisher="Rajeev Boobna and dprZoft" />
+        <Identity Id="c3b55d75-8ea6-3936-a8853-1d105zd38z19" Version="1.4.1.22" Language="en-US" Publisher="Rajeev Boobna and dprZoft" />
         <DisplayName>DiffFinder</DisplayName>
         <Description xml:space="preserve">The extension allows you to compare files in two shelvesets.
 Version for VS2022.


### PR DESCRIPTION
* Update Package and CommandSet GUIDs to different values than ShelvesetComparer -> this allows both extensions and their commands to exist in parallel.
  * fixes #19 
* changed version scheme to allow releases with minor fixes like this: 1.4.1 (-> (old) 1.0.4 == (new)1.4.0)
