### PR TITLE
Fixed issue comparing differences of two files with spaces in their path

### DIFF
--- a/DiffFinder.Tests/DiffFinder.Tests.csproj
+++ b/DiffFinder.Tests/DiffFinder.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>DiffFinder.Tests</RootNamespace>
+    <AssemblyName>DiffFinder.Tests</AssemblyName>
+    <!-- referencing the VSIX project drags in the Visual Studio SDK, whose assembly versions conflict with the ones shipping in the IDE -->
+    <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);MSB3277</MSBuildWarningsAsMessages>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DiffFinder\DiffFinder.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/DiffFinder.Tests/DiffToolArgumentBuilderTests.cs
+++ b/DiffFinder.Tests/DiffToolArgumentBuilderTests.cs
@@ -1,0 +1,137 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DiffFinder.Tests
+{
+    /// <summary>
+    /// Tests for <see cref="DiffToolArgumentBuilder"/>.
+    /// </summary>
+    [TestClass]
+    public class DiffToolArgumentBuilderTests
+    {
+        private const string FirstFile = @"C:\Users\first last\AppData\Local\Temp\tmp1A2B.tmp";
+
+        private const string SecondFile = @"C:\Users\first last\AppData\Local\Temp\tmp3C4D.tmp";
+
+        private const string FirstLabel = "$/Project/My Folder/File.cs;Shelveset One";
+
+        private const string SecondLabel = "$/Project/My Folder/File.cs;Shelveset Two";
+
+        /// <summary>
+        /// The regression test for https://github.com/dprZoft/shelvesetcomparer/issues/17: an unquoted
+        /// template has to produce two arguments, not the four or more the tool would read as a 3-way merge.
+        /// </summary>
+        [TestMethod]
+        public void Build_UnquotedTemplateWithSpacesInPaths_QuotesBothFiles()
+        {
+            var arguments = DiffToolArgumentBuilder.Build("%1 %2", FirstFile, SecondFile, FirstLabel, SecondLabel);
+
+            Assert.AreEqual($"\"{FirstFile}\" \"{SecondFile}\"", arguments);
+        }
+
+        [TestMethod]
+        public void Build_TemplateAlreadyQuoted_DoesNotAddASecondPairOfQuotes()
+        {
+            var arguments = DiffToolArgumentBuilder.Build("\"%1\" \"%2\"", FirstFile, SecondFile, FirstLabel, SecondLabel);
+
+            Assert.AreEqual($"\"{FirstFile}\" \"{SecondFile}\"", arguments);
+        }
+
+        [TestMethod]
+        public void Build_TemplateQuotesOnlySomePlaceholders_QuotesOnlyTheUnquotedOnes()
+        {
+            var arguments = DiffToolArgumentBuilder.Build("\"%1\" %2", FirstFile, SecondFile, FirstLabel, SecondLabel);
+
+            Assert.AreEqual($"\"{FirstFile}\" \"{SecondFile}\"", arguments);
+        }
+
+        [TestMethod]
+        public void Build_TemplateWithLabels_QuotesTheLabels()
+        {
+            var arguments = DiffToolArgumentBuilder.Build("%1 %2 /title1=%6 /title2=%7", FirstFile, SecondFile, FirstLabel, SecondLabel);
+
+            Assert.AreEqual($"\"{FirstFile}\" \"{SecondFile}\" /title1=\"{FirstLabel}\" /title2=\"{SecondLabel}\"", arguments);
+        }
+
+        [TestMethod]
+        public void Build_TemplateWithQuotedLabels_DoesNotAddASecondPairOfQuotes()
+        {
+            var arguments = DiffToolArgumentBuilder.Build("/title1=\"%6\" /title2=\"%7\"", FirstFile, SecondFile, FirstLabel, SecondLabel);
+
+            Assert.AreEqual($"/title1=\"{FirstLabel}\" /title2=\"{SecondLabel}\"", arguments);
+        }
+
+        [TestMethod]
+        public void Build_UnsupportedPlaceholders_AreLeftUntouched()
+        {
+            var arguments = DiffToolArgumentBuilder.Build("%3 %4 %5 %8 %9", FirstFile, SecondFile, FirstLabel, SecondLabel);
+
+            Assert.AreEqual("%3 %4 %5 %8 %9", arguments);
+        }
+
+        [TestMethod]
+        public void Build_ValueContainingAPlaceholder_IsNotSubstitutedAgain()
+        {
+            var firstFile = @"C:\Temp\a %2 b.cs";
+
+            var arguments = DiffToolArgumentBuilder.Build("%1 %2", firstFile, SecondFile, FirstLabel, SecondLabel);
+
+            Assert.AreEqual($"\"{firstFile}\" \"{SecondFile}\"", arguments);
+        }
+
+        [TestMethod]
+        public void Build_ValueContainingAQuote_EscapesTheQuote()
+        {
+            var arguments = DiffToolArgumentBuilder.Build("%1", "C:\\Temp\\a\"b.cs", SecondFile, FirstLabel, SecondLabel);
+
+            Assert.AreEqual("\"C:\\Temp\\a\\\"b.cs\"", arguments);
+        }
+
+        [TestMethod]
+        public void Build_ValueEndingWithABackslash_DoublesTheTrailingBackslash()
+        {
+            var arguments = DiffToolArgumentBuilder.Build("%1", @"C:\Temp\my folder\", SecondFile, FirstLabel, SecondLabel);
+
+            Assert.AreEqual("\"C:\\Temp\\my folder\\\\\"", arguments);
+        }
+
+        [TestMethod]
+        public void Build_QuotedTemplateAndValueEndingWithABackslash_DoublesTheTrailingBackslash()
+        {
+            var arguments = DiffToolArgumentBuilder.Build("\"%1\"", @"C:\Temp\my folder\", SecondFile, FirstLabel, SecondLabel);
+
+            Assert.AreEqual("\"C:\\Temp\\my folder\\\\\"", arguments);
+        }
+
+        [TestMethod]
+        public void Build_NullValue_ProducesAnEmptyArgument()
+        {
+            var arguments = DiffToolArgumentBuilder.Build("%1 %2", null, SecondFile, FirstLabel, SecondLabel);
+
+            Assert.AreEqual($"\"\" \"{SecondFile}\"", arguments);
+        }
+
+        [TestMethod]
+        public void Build_NullTemplate_ReturnsNull()
+        {
+            var arguments = DiffToolArgumentBuilder.Build(null, FirstFile, SecondFile, FirstLabel, SecondLabel);
+
+            Assert.IsNull(arguments);
+        }
+
+        [TestMethod]
+        public void Build_EmptyTemplate_ReturnsEmpty()
+        {
+            var arguments = DiffToolArgumentBuilder.Build(string.Empty, FirstFile, SecondFile, FirstLabel, SecondLabel);
+
+            Assert.AreEqual(string.Empty, arguments);
+        }
+
+        [TestMethod]
+        public void Build_TemplateWithoutPlaceholders_IsLeftUntouched()
+        {
+            var arguments = DiffToolArgumentBuilder.Build("/e /u /wl", FirstFile, SecondFile, FirstLabel, SecondLabel);
+
+            Assert.AreEqual("/e /u /wl", arguments);
+        }
+    }
+}

--- a/DiffFinder.sln
+++ b/DiffFinder.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 15.0.27130.2036
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DiffFinder", "DiffFinder\DiffFinder.csproj", "{7C432ACE-1D8C-4E09-A18F-6B8B1C96D445}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DiffFinder.Tests", "DiffFinder.Tests\DiffFinder.Tests.csproj", "{2F1E8C4B-7A63-4D95-9C0E-3B5A6D8E1F27}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{7C432ACE-1D8C-4E09-A18F-6B8B1C96D445}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7C432ACE-1D8C-4E09-A18F-6B8B1C96D445}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7C432ACE-1D8C-4E09-A18F-6B8B1C96D445}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2F1E8C4B-7A63-4D95-9C0E-3B5A6D8E1F27}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2F1E8C4B-7A63-4D95-9C0E-3B5A6D8E1F27}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2F1E8C4B-7A63-4D95-9C0E-3B5A6D8E1F27}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2F1E8C4B-7A63-4D95-9C0E-3B5A6D8E1F27}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/DiffFinder/DiffFinder.csproj
+++ b/DiffFinder/DiffFinder.csproj
@@ -84,6 +84,7 @@
     <Compile Include="ViewExtensions\SortGlyphAdorner.cs" />
     <Compile Include="ViewModel\FileComparisonViewModel.cs" />
     <Compile Include="ViewModel\ShelvesetComparerViewModel.cs" />
+    <Compile Include="Views\DiffToolArgumentBuilder.cs" />
     <Compile Include="Views\MainView.xaml.cs">
       <DependentUpon>MainView.xaml</DependentUpon>
     </Compile>

--- a/DiffFinder/Views/DiffToolArgumentBuilder.cs
+++ b/DiffFinder/Views/DiffToolArgumentBuilder.cs
@@ -1,0 +1,112 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace DiffFinder
+{
+    /// <summary>
+    /// Builds the command line arguments passed to the external difference tool configured in Visual Studio.
+    /// </summary>
+    public static class DiffToolArgumentBuilder
+    {
+        /// <summary>
+        /// Matches the diff tool argument placeholders %1 through %9
+        /// </summary>
+        private static readonly Regex Placeholders = new Regex("%[1-9]", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Substitutes the diff tool argument placeholders, quoting each substituted value so that paths
+        /// and labels containing spaces are passed to the tool as a single argument.
+        /// %1: Original file, %2: Modified file, %3: Base file, %4: Merged file, %5: Diff command-line options,
+        /// %6: Original file label, %7: Modified file label, %8, %9: Base file and merged file label.
+        /// Only %1, %2, %6 and %7 are substituted, the remaining placeholders are left untouched.
+        /// A placeholder the template already wraps in quotes is substituted without adding another pair.
+        /// </summary>
+        /// <param name="argumentsTemplate">The arguments template configured for the tool</param>
+        /// <param name="firstFileName">The path of the original file</param>
+        /// <param name="secondFileName">The path of the modified file</param>
+        /// <param name="firstDisplayName">The label of the original file</param>
+        /// <param name="secondDisplayName">The label of the modified file</param>
+        /// <returns>The arguments to pass to the tool</returns>
+        public static string Build(string argumentsTemplate, string firstFileName, string secondFileName, string firstDisplayName, string secondDisplayName)
+        {
+            if (string.IsNullOrEmpty(argumentsTemplate))
+            {
+                return argumentsTemplate;
+            }
+
+            return Placeholders.Replace(argumentsTemplate, match =>
+            {
+                string value;
+                switch (match.Value)
+                {
+                    case "%1":
+                        value = firstFileName;
+                        break;
+                    case "%2":
+                        value = secondFileName;
+                        break;
+                    case "%6":
+                        value = firstDisplayName;
+                        break;
+                    case "%7":
+                        value = secondDisplayName;
+                        break;
+                    default:
+                        // the placeholder is not supported, leave it as it is
+                        return match.Value;
+                }
+
+                value = Escape(value);
+
+                // if the template already wraps the placeholder in quotes there is no need to add another pair
+                var precededByQuote = match.Index > 0 && argumentsTemplate[match.Index - 1] == '"';
+                var followedByQuote = match.Index + match.Length < argumentsTemplate.Length && argumentsTemplate[match.Index + match.Length] == '"';
+
+                return precededByQuote && followedByQuote ? value : "\"" + value + "\"";
+            });
+        }
+
+        /// <summary>
+        /// Escapes a value so that it survives being wrapped in double quotes, following the rules the
+        /// Windows command line parser applies: a double quote is escaped with a backslash, and every
+        /// backslash preceding a double quote, including the closing one, is doubled.
+        /// </summary>
+        /// <param name="value">The value to escape</param>
+        /// <returns>The escaped value</returns>
+        private static string Escape(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return string.Empty;
+            }
+
+            var escaped = new StringBuilder(value.Length);
+            var backslashes = 0;
+            foreach (var character in value)
+            {
+                if (character == '\\')
+                {
+                    backslashes++;
+                    continue;
+                }
+
+                if (character == '"')
+                {
+                    escaped.Append('\\', (backslashes * 2) + 1);
+                }
+                else
+                {
+                    escaped.Append('\\', backslashes);
+                }
+
+                backslashes = 0;
+                escaped.Append(character);
+            }
+
+            // the trailing backslashes precede the closing quote, so they have to be doubled as well
+            escaped.Append('\\', backslashes * 2);
+
+            return escaped.ToString();
+        }
+    }
+}

--- a/DiffFinder/Views/MainView.xaml.cs
+++ b/DiffFinder/Views/MainView.xaml.cs
@@ -106,11 +106,12 @@ namespace DiffFinder
             else
             {
                 // So there is a tool configured. Let's use it
-                // $3: Base file, %4: Merged file, %5: Diff command-line options, %6: original file label, %7: Modified file label, %8,9: base file and merged file label
-                diffToolCommandArguments = diffToolCommandArguments.Replace("%1", firstFileName)
-                    .Replace("%2", secondFileName)
-                    .Replace("%6", firstDisplayName)
-                    .Replace("%7", secondDisplayName);
+                diffToolCommandArguments = DiffToolArgumentBuilder.Build(
+                    diffToolCommandArguments,
+                    firstFileName,
+                    secondFileName,
+                    firstDisplayName,
+                    secondDisplayName);
                 var startInfo = new ProcessStartInfo()
                 {
                     Arguments = diffToolCommandArguments,


### PR DESCRIPTION
Added DiffToolArgumentBuilder and unit tests.
Introduce DiffToolArgumentBuilder for building and escaping diff tool arguments. Refactor MainView.xaml.cs to use the new builder. Add DiffFinder.Tests project with MSTest and comprehensive tests for argument handling. Update solution to include the test project.
Fixes #17