### PR TITLE
Do not bundle Team Foundation assemblies in the VSIX

### DIFF
--- a/DiffFinder/DiffFinder.csproj
+++ b/DiffFinder/DiffFinder.csproj
@@ -118,26 +118,32 @@
     <Reference Include="Microsoft.TeamFoundation.Client, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\ReferenceVS2026\Microsoft.TeamFoundation.Client.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.Common, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\ReferenceVS2026\Microsoft.TeamFoundation.Common.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.Controls, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\ReferenceVS2026\Microsoft.TeamFoundation.Controls.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.VersionControl.Client, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\ReferenceVS2026\Microsoft.TeamFoundation.VersionControl.Client.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TeamFoundation, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\ReferenceVS2026\Microsoft.VisualStudio.TeamFoundation.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.VersionControl.Controls, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\ReferenceVS2026\Microsoft.TeamFoundation.VersionControl.Controls.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />


### PR DESCRIPTION
The six Team Foundation references had no `<Private>` setting, so CopyLocal defaulted to true and the VSSDK packaged the assemblies inside the VSIX. At runtime the extension loaded its own copies, which gave `ITeamExplorerSection` a different type identity from the one the Team Explorer Framework resolves, so creating the section host failed with `CompositionContractMismatchException`.

`<Private>false</Private>` keeps the `HintPath` entries for compilation and leaves the assemblies out of the package, so the ones installed with Visual Studio are loaded at runtime.

Verified by building in Release and comparing the VSIX contents: the six assemblies are present before the change and absent after it. Team Explorer loads with no exception on VS2026 18.4.3.

Fixes #18
